### PR TITLE
New data nodes names & schemas

### DIFF
--- a/aiida_aurora/calculations/cycler.py
+++ b/aiida_aurora/calculations/cycler.py
@@ -11,9 +11,9 @@ from aiida.common import datastructures
 from aiida.engine import CalcJob
 from aiida.orm import ArrayData, SinglefileData
 
-from aiida_aurora.data.battery import BatterySample, BatteryState
-from aiida_aurora.data.control import TomatoSettings
-from aiida_aurora.data.experiment import CyclingSpecs
+from aiida_aurora.data.battery import BatterySampleData, BatteryStateData
+from aiida_aurora.data.control import TomatoSettingsData
+from aiida_aurora.data.experiment import CyclingSpecsData
 
 
 class BatteryCyclerExperiment(CalcJob):
@@ -28,7 +28,6 @@ class BatteryCyclerExperiment(CalcJob):
     @classmethod
     def define(cls, spec):
         """Define inputs and outputs of the calculation."""
-        # yapf: disable
         super().define(spec)
 
         # set default values for AiiDA options
@@ -43,12 +42,12 @@ class BatteryCyclerExperiment(CalcJob):
 
         # new ports
         spec.input('metadata.options.output_filename', valid_type=str, default=cls._OUTPUT_FILE_PREFIX)
-        spec.input('battery_sample', valid_type=BatterySample, help='Battery sample used.')
-        spec.input('technique', valid_type=CyclingSpecs, help='Experiment specifications.')
-        spec.input('control_settings', valid_type=TomatoSettings, help='Experiment control settings.')
+        spec.input('battery_sample', valid_type=BatterySampleData, help='Battery sample used.')
+        spec.input('technique', valid_type=CyclingSpecsData, help='Experiment specifications.')
+        spec.input('control_settings', valid_type=TomatoSettingsData, help='Experiment control settings.')
         spec.output('results', valid_type=ArrayData, help='Results of the experiment.')
         spec.output('raw_data', valid_type=SinglefileData, help='Raw data retrieved.')
-        # spec.output('battery_state', valid_type=BatteryState, help='State of the battery after the experiment.')
+        # spec.output('battery_state', valid_type=BatteryStateData, help='State of the battery after the experiment.')
 
         spec.exit_code(300, 'ERROR_MISSING_OUTPUT_FILES', message='Experiment did not produce any kind of output file.')
         spec.exit_code(301, 'ERROR_MISSING_JSON_FILE', message='Experiment did not produce an output json file.')

--- a/aiida_aurora/calculations/cycler.py
+++ b/aiida_aurora/calculations/cycler.py
@@ -21,9 +21,10 @@ class BatteryCyclerExperiment(CalcJob):
     AiiDA calculation plugin for the tomato instrument automation package.
     https://github.com/dgbowl/tomato
     """
-    _INPUT_PAYLOAD_YAML_FILE = 'payload.yaml'
-    _INPUT_PAYLOAD_VERSION = '0.2'
-    _OUTPUT_FILE_PREFIX = 'results'
+
+    _INPUT_PAYLOAD_YAML_FILE = "payload.yaml"
+    _INPUT_PAYLOAD_VERSION = "0.2"
+    _OUTPUT_FILE_PREFIX = "results"
 
     @classmethod
     def define(cls, spec):
@@ -31,30 +32,66 @@ class BatteryCyclerExperiment(CalcJob):
         super().define(spec)
 
         # set default values for AiiDA options
-        spec.inputs['metadata']['options']['resources'].default = {  # REQUIRED?
-            'num_machines': 1,
+        spec.inputs["metadata"]["options"]["resources"].default = {  # REQUIRED?
+            "num_machines": 1,
         }
-        spec.inputs['metadata']['options']['parser_name'].default = 'aurora'
-        spec.inputs['metadata']['options']['withmpi'].default = False
-        spec.inputs['metadata']['options']['input_filename'].default = cls._INPUT_PAYLOAD_YAML_FILE
+        spec.inputs["metadata"]["options"]["parser_name"].default = "aurora"
+        spec.inputs["metadata"]["options"]["withmpi"].default = False
+        spec.inputs["metadata"]["options"][
+            "input_filename"
+        ].default = cls._INPUT_PAYLOAD_YAML_FILE
         # spec.inputs['metadata']['options']['scheduler_stderr'].default = ''
         # spec.inputs['metadata']['options']['scheduler_stdout'].default = ''
 
         # new ports
-        spec.input('metadata.options.output_filename', valid_type=str, default=cls._OUTPUT_FILE_PREFIX)
-        spec.input('battery_sample', valid_type=BatterySampleData, help='Battery sample used.')
-        spec.input('technique', valid_type=CyclingSpecsData, help='Experiment specifications.')
-        spec.input('control_settings', valid_type=TomatoSettingsData, help='Experiment control settings.')
-        spec.output('results', valid_type=ArrayData, help='Results of the experiment.')
-        spec.output('raw_data', valid_type=SinglefileData, help='Raw data retrieved.')
+        spec.input(
+            "metadata.options.output_filename",
+            valid_type=str,
+            default=cls._OUTPUT_FILE_PREFIX,
+        )
+        spec.input(
+            "battery_sample", valid_type=BatterySampleData, help="Battery sample used."
+        )
+        spec.input(
+            "technique", valid_type=CyclingSpecsData, help="Experiment specifications."
+        )
+        spec.input(
+            "control_settings",
+            valid_type=TomatoSettingsData,
+            help="Experiment control settings.",
+        )
+        spec.output("results", valid_type=ArrayData, help="Results of the experiment.")
+        spec.output("raw_data", valid_type=SinglefileData, help="Raw data retrieved.")
         # spec.output('battery_state', valid_type=BatteryStateData, help='State of the battery after the experiment.')
 
-        spec.exit_code(300, 'ERROR_MISSING_OUTPUT_FILES', message='Experiment did not produce any kind of output file.')
-        spec.exit_code(301, 'ERROR_MISSING_JSON_FILE', message='Experiment did not produce an output json file.')
-        spec.exit_code(302, 'ERROR_MISSING_ZIP_FILE', message='Experiment did not produce a zip file with raw data.')
-        spec.exit_code(311, 'ERROR_COMPLETED_ERROR', message='The tomato job was marked as completed with an error.')
-        spec.exit_code(312, 'ERROR_COMPLETED_CANCELLED', message='The tomato job was marked as cancelled.')
-        spec.exit_code(400, 'ERROR_PARSING_JSON_FILE', message='Parsing of json file failed.')
+        spec.exit_code(
+            300,
+            "ERROR_MISSING_OUTPUT_FILES",
+            message="Experiment did not produce any kind of output file.",
+        )
+        spec.exit_code(
+            301,
+            "ERROR_MISSING_JSON_FILE",
+            message="Experiment did not produce an output json file.",
+        )
+        spec.exit_code(
+            302,
+            "ERROR_MISSING_ZIP_FILE",
+            message="Experiment did not produce a zip file with raw data.",
+        )
+        spec.exit_code(
+            311,
+            "ERROR_COMPLETED_ERROR",
+            message="The tomato job was marked as completed with an error.",
+        )
+        spec.exit_code(
+            312,
+            "ERROR_COMPLETED_CANCELLED",
+            message="The tomato job was marked as cancelled.",
+        )
+        spec.exit_code(
+            400, "ERROR_PARSING_JSON_FILE", message="Parsing of json file failed."
+        )
 
     def prepare_for_submission(self, folder):
         """
@@ -66,43 +103,55 @@ class BatteryCyclerExperiment(CalcJob):
         """
 
         # if connecting to a Windows PowerShell computer, change the extension of the submit script to '.ps1'
-        if self.inputs.code.computer.transport_type == 'sshtowin':
-            submit_script_filename = self.node.get_option('submit_script_filename')
-            if not submit_script_filename.endswith('.ps1'):
-                if submit_script_filename.endswith('.sh'):
-                    submit_script_filename = submit_script_filename[:-3] + '.ps1'
+        if self.inputs.code.computer.transport_type == "sshtowin":
+            submit_script_filename = self.node.get_option("submit_script_filename")
+            if not submit_script_filename.endswith(".ps1"):
+                if submit_script_filename.endswith(".sh"):
+                    submit_script_filename = submit_script_filename[:-3] + ".ps1"
                 else:
-                    submit_script_filename(submit_script_filename + '.ps1')
-                self.node.backend_entity.set_attribute('submit_script_filename', submit_script_filename)
+                    submit_script_filename(submit_script_filename + ".ps1")
+                self.node.backend_entity.set_attribute(
+                    "submit_script_filename", submit_script_filename
+                )
 
         # prepare the payload
         # TODO: use dgbowl_schemas module
         ## from dgbowl_schemas.tomato.payload_0_1.tomato import Tomato
         ## - should 'version: "0.1"' be written in the submit script?
         ## - name of the file containing the sample and method
-        tomato_schema_module = import_module(f"aurora.schemas.tomato_{self._INPUT_PAYLOAD_VERSION.replace('.', 'p')}")
+        tomato_schema_module = import_module(
+            f"aurora.schemas.tomato_{self._INPUT_PAYLOAD_VERSION.replace('.', 'p')}"
+        )
         TomatoSchema = tomato_schema_module.tomato.Tomato
 
         tomato_dict = self.inputs.control_settings.get_dict()
-        if tomato_dict['output']['prefix'] is None:
-            tomato_dict['output']['prefix'] = self._OUTPUT_FILE_PREFIX
+        if tomato_dict["output"]["prefix"] is None:
+            tomato_dict["output"]["prefix"] = self._OUTPUT_FILE_PREFIX
         else:
-            self._OUTPUT_FILE_PREFIX = tomato_dict['output']['prefix']
+            self._OUTPUT_FILE_PREFIX = tomato_dict["output"]["prefix"]
         payload = tomato_schema_module.TomatoPayload(
-            version = self._INPUT_PAYLOAD_VERSION,
-            sample = tomato_schema_module.sample.convert_batterysample_to_sample(self.inputs.battery_sample.get_dict()),
-            method = tomato_schema_module.method.convert_electrochemsequence_to_method_list(
-                self.inputs.technique.get_dict()),
-            tomato = TomatoSchema(**tomato_dict),
+            version=self._INPUT_PAYLOAD_VERSION,
+            sample=tomato_schema_module.sample.convert_batterysample_to_sample(
+                self.inputs.battery_sample.get_dict()
+            ),
+            method=tomato_schema_module.method.convert_electrochemsequence_to_method_list(
+                self.inputs.technique.get_dict()
+            ),
+            tomato=TomatoSchema(**tomato_dict),
         )
-        with folder.open(self.options.input_filename, 'w', encoding='utf8') as handle:
+        with folder.open(self.options.input_filename, "w", encoding="utf8") as handle:
             handle.write(yaml.dump(payload.dict()))
 
         codeinfo = datastructures.CodeInfo()
 
         # the calculation code should be 'ketchup', so we add the following `cmdline_params`
         # in order to submit the payload to tomato
-        codeinfo.cmdline_params = ['submit', '--jobname', '$JOB_TITLE', self._INPUT_PAYLOAD_YAML_FILE]
+        codeinfo.cmdline_params = [
+            "submit",
+            "--jobname",
+            "$JOB_TITLE",
+            self._INPUT_PAYLOAD_YAML_FILE,
+        ]
         codeinfo.code_uuid = self.inputs.code.uuid
         codeinfo.withmpi = self.inputs.metadata.options.withmpi
 
@@ -110,7 +159,7 @@ class BatteryCyclerExperiment(CalcJob):
         calcinfo = datastructures.CalcInfo()
         calcinfo.codes_info = [codeinfo]
         calcinfo.local_copy_list = []
-        calcinfo.retrieve_list = [f'{self._OUTPUT_FILE_PREFIX}.json']
-        calcinfo.retrieve_temporary_list = [f'{self._OUTPUT_FILE_PREFIX}.zip']
+        calcinfo.retrieve_list = [f"{self._OUTPUT_FILE_PREFIX}.json"]
+        calcinfo.retrieve_temporary_list = [f"{self._OUTPUT_FILE_PREFIX}.zip"]
 
         return calcinfo

--- a/aiida_aurora/calculations/fake.py
+++ b/aiida_aurora/calculations/fake.py
@@ -8,8 +8,8 @@ from aiida.engine import CalcJob
 # from aiida.orm import SinglefileData
 from aiida.orm import Dict
 
-from aiida_aurora.data.battery import BatterySample, BatteryState
-from aiida_aurora.data.experiment import CyclingSpecs
+from aiida_aurora.data.battery import BatterySampleData, BatteryStateData
+from aiida_aurora.data.experiment import CyclingSpecsData
 
 
 class BatteryFakeExperiment(CalcJob):
@@ -26,7 +26,6 @@ class BatteryFakeExperiment(CalcJob):
     @classmethod
     def define(cls, spec):
         """Define inputs and outputs of the calculation."""
-        # yapf: disable
         super().define(spec)
 
         # set default values for AiiDA options
@@ -38,10 +37,10 @@ class BatteryFakeExperiment(CalcJob):
 
         # new ports
         spec.input('metadata.options.output_filename', valid_type=str, default=cls._DEFAULT_STDOUT_FILE)
-        spec.input('battery_sample', valid_type=BatterySample, help='Battery sample used.')
-        spec.input('exp_specs', valid_type=CyclingSpecs, help='Experiment specifications.')
+        spec.input('battery_sample', valid_type=BatterySampleData, help='Battery sample used.')
+        spec.input('exp_specs', valid_type=CyclingSpecsData, help='Experiment specifications.')
         spec.output('results', valid_type=Dict, help='Results of the experiment.')  # a proper type should be defined
-        #spec.output('battery_state', valid_type=BatteryState, help='State of the battery after the experiment.')
+        #spec.output('battery_state', valid_type=BatteryStateData, help='State of the battery after the experiment.')
 
         spec.exit_code(300, 'ERROR_MISSING_OUTPUT_FILES', message='Calculation did not produce all expected output files.')
 

--- a/aiida_aurora/calculations/fake.py
+++ b/aiida_aurora/calculations/fake.py
@@ -5,6 +5,7 @@ Register calculations via the "aiida.calculations" entry point in setup.json.
 """
 from aiida.common import datastructures
 from aiida.engine import CalcJob
+
 # from aiida.orm import SinglefileData
 from aiida.orm import Dict
 
@@ -18,10 +19,11 @@ class BatteryFakeExperiment(CalcJob):
 
     Simple AiiDA plugin that sends input data as json files to the fake Aurora server API script.
     """
-    _INPUT_BATTERY_JSON_FILE = 'battery.json'
-    _INPUT_EXPERIMENT_JSON_FILE = 'experiment.json'
-    _OUTPUT_JSON_FILE = 'output.json'
-    _DEFAULT_STDOUT_FILE = 'output.log'
+
+    _INPUT_BATTERY_JSON_FILE = "battery.json"
+    _INPUT_EXPERIMENT_JSON_FILE = "experiment.json"
+    _OUTPUT_JSON_FILE = "output.json"
+    _DEFAULT_STDOUT_FILE = "output.log"
 
     @classmethod
     def define(cls, spec):
@@ -29,20 +31,34 @@ class BatteryFakeExperiment(CalcJob):
         super().define(spec)
 
         # set default values for AiiDA options
-        spec.inputs['metadata']['options']['resources'].default = {
-            'num_machines': 1,
-            'num_mpiprocs_per_machine': 1,
+        spec.inputs["metadata"]["options"]["resources"].default = {
+            "num_machines": 1,
+            "num_mpiprocs_per_machine": 1,
         }
-        spec.inputs['metadata']['options']['parser_name'].default = 'aurora'
+        spec.inputs["metadata"]["options"]["parser_name"].default = "aurora"
 
         # new ports
-        spec.input('metadata.options.output_filename', valid_type=str, default=cls._DEFAULT_STDOUT_FILE)
-        spec.input('battery_sample', valid_type=BatterySampleData, help='Battery sample used.')
-        spec.input('exp_specs', valid_type=CyclingSpecsData, help='Experiment specifications.')
-        spec.output('results', valid_type=Dict, help='Results of the experiment.')  # a proper type should be defined
-        #spec.output('battery_state', valid_type=BatteryStateData, help='State of the battery after the experiment.')
+        spec.input(
+            "metadata.options.output_filename",
+            valid_type=str,
+            default=cls._DEFAULT_STDOUT_FILE,
+        )
+        spec.input(
+            "battery_sample", valid_type=BatterySampleData, help="Battery sample used."
+        )
+        spec.input(
+            "exp_specs", valid_type=CyclingSpecsData, help="Experiment specifications."
+        )
+        spec.output(
+            "results", valid_type=Dict, help="Results of the experiment."
+        )  # a proper type should be defined
+        # spec.output('battery_state', valid_type=BatteryStateData, help='State of the battery after the experiment.')
 
-        spec.exit_code(300, 'ERROR_MISSING_OUTPUT_FILES', message='Calculation did not produce all expected output files.')
+        spec.exit_code(
+            300,
+            "ERROR_MISSING_OUTPUT_FILES",
+            message="Calculation did not produce all expected output files.",
+        )
 
     def prepare_for_submission(self, folder):
         """
@@ -53,17 +69,21 @@ class BatteryFakeExperiment(CalcJob):
         :return: `aiida.common.datastructures.CalcInfo` instance
         """
 
-        with open(self._INPUT_BATTERY_JSON_FILE, 'w') as handle:
+        with open(self._INPUT_BATTERY_JSON_FILE, "w") as handle:
             handle.write(self.inputs.battery_sample.get_json())
-        with open(self._INPUT_EXPERIMENT_JSON_FILE, 'w') as handle:
+        with open(self._INPUT_EXPERIMENT_JSON_FILE, "w") as handle:
             handle.write(self.inputs.exp_specs.get_json())
 
         codeinfo = datastructures.CodeInfo()
         # codeinfo.cmdline_params = self.inputs.parameters.cmdline_params(
         #     file1_name=self.inputs.file1.filename,
         #     file2_name=self.inputs.file2.filename)
-        codeinfo.cmdline_params = [self._INPUT_BATTERY_JSON_FILE, self._INPUT_EXPERIMENT_JSON_FILE,
-                    '-o', self._OUTPUT_JSON_FILE]
+        codeinfo.cmdline_params = [
+            self._INPUT_BATTERY_JSON_FILE,
+            self._INPUT_EXPERIMENT_JSON_FILE,
+            "-o",
+            self._OUTPUT_JSON_FILE,
+        ]
         codeinfo.code_uuid = self.inputs.code.uuid
         codeinfo.stdout_name = self.metadata.options.output_filename
         codeinfo.withmpi = self.inputs.metadata.options.withmpi
@@ -72,6 +92,9 @@ class BatteryFakeExperiment(CalcJob):
         calcinfo = datastructures.CalcInfo()
         calcinfo.codes_info = [codeinfo]
         calcinfo.local_copy_list = []
-        calcinfo.retrieve_list = [self.metadata.options.output_filename, self._OUTPUT_JSON_FILE]
+        calcinfo.retrieve_list = [
+            self.metadata.options.output_filename,
+            self._OUTPUT_JSON_FILE,
+        ]
 
         return calcinfo

--- a/aiida_aurora/data/__init__.py
+++ b/aiida_aurora/data/__init__.py
@@ -4,6 +4,6 @@ Data types provided by plugin
 Register data types via the "aiida.data" entry point in setup.json.
 """
 
-from .battery import BatterySample, BatteryState
-from .control import TomatoSettings
-from .experiment import CyclingSpecs
+from .battery import BatterySampleData, BatteryStateData
+from .control import TomatoSettingsData
+from .experiment import CyclingSpecsData

--- a/aiida_aurora/data/battery.py
+++ b/aiida_aurora/data/battery.py
@@ -13,7 +13,7 @@ import yaml
 from aiida.orm import Dict
 
 
-class BatterySample(Dict):  # pylint: disable=too-many-ancestors
+class BatterySampleData(Dict):  # pylint: disable=too-many-ancestors
     """
     A battery sample data object.
 
@@ -28,7 +28,7 @@ class BatterySample(Dict):  # pylint: disable=too-many-ancestors
         """
         Constructor for the data class
 
-        Usage: ``BatterySample(dict{...})``
+        Usage: ``BatterySampleData(dict{...})``
 
         :param parameters_dict: dictionary with battery specifications
         :param type parameters_dict: dict
@@ -43,7 +43,7 @@ class BatterySample(Dict):  # pylint: disable=too-many-ancestors
 
         Uses the voluptuous package for validation. Find out about allowed keys using::
 
-            print(BatterySample.schema)
+            print(BatterySampleData.schema)
 
         :param parameters_dict: dictionary with battery specifications
         :param type parameters_dict: dict
@@ -58,14 +58,14 @@ class BatterySample(Dict):  # pylint: disable=too-many-ancestors
         return d
 
     def get_json(self):
-        """Get a JSON file containing the BatterySample specs."""
+        """Get a JSON file containing the BatterySampleData specs."""
 
         # this can be customized to fit the desired format
         object_to_be_serialized = self.get_dict()
         return json.dumps(object_to_be_serialized)
 
     def get_yaml(self):
-        """Get a YAML file containing the BatterySample specs."""
+        """Get a YAML file containing the BatterySampleData specs."""
 
         # this can be customized to fit the desired format
         object_to_be_serialized = {"sample": self.get_dict()}
@@ -84,7 +84,7 @@ class BatterySample(Dict):  # pylint: disable=too-many-ancestors
         return string
 
 
-class BatteryState(Dict):  # pylint: disable=too-many-ancestors
+class BatteryStateData(Dict):  # pylint: disable=too-many-ancestors
     """
     A battery state data object.
 
@@ -100,7 +100,7 @@ class BatteryState(Dict):  # pylint: disable=too-many-ancestors
         """
         Constructor for the data class
 
-        Usage: ``BatteryState(dict{...})``
+        Usage: ``BatteryStateData(dict{...})``
 
         :param parameters_dict: dictionary with battery specifications
         :param type parameters_dict: dict
@@ -113,7 +113,7 @@ class BatteryState(Dict):  # pylint: disable=too-many-ancestors
 
         Uses the voluptuous package for validation. Find out about allowed keys using::
 
-            print(BatteryState.schema)
+            print(BatteryStateData.schema)
 
         :param parameters_dict: dictionary with battery specifications
         :param type parameters_dict: dict

--- a/aiida_aurora/data/battery.py
+++ b/aiida_aurora/data/battery.py
@@ -6,8 +6,8 @@ Register data types via the "aiida.data" entry point in setup.json.
 
 import json
 
-from aurora.schemas.data_schemas import BatterySample as BatterySampleSchema
-from aurora.schemas.data_schemas import BatteryState as BatteryStateSchema
+from aurora.schemas.battery import BatterySample as BatterySampleSchema
+from aurora.schemas.battery import BatteryState as BatteryStateSchema
 import yaml
 
 from aiida.orm import Dict

--- a/aiida_aurora/data/control.py
+++ b/aiida_aurora/data/control.py
@@ -1,19 +1,15 @@
 """
 A dummy experiment specifications class.
 """
-
-from importlib import import_module
 import json
 
+from aurora.schemas.dgbowl_schemas import conversion_map
 import yaml
 
 from aiida.orm import Dict
 
 TOMATO_PAYLOAD_VERSION = "0.2"
-tomato_schema_module = import_module(
-    f"aurora.schemas.tomato_{TOMATO_PAYLOAD_VERSION.replace('.', 'p')}"
-)
-TomatoSchema = tomato_schema_module.tomato.Tomato
+TomatoSchema = conversion_map[TOMATO_PAYLOAD_VERSION]["tomato"]
 
 
 class TomatoSettingsData(Dict):  # pylint: disable=too-many-ancestors

--- a/aiida_aurora/data/control.py
+++ b/aiida_aurora/data/control.py
@@ -16,7 +16,7 @@ tomato_schema_module = import_module(
 TomatoSchema = tomato_schema_module.tomato.Tomato
 
 
-class TomatoSettings(Dict):  # pylint: disable=too-many-ancestors
+class TomatoSettingsData(Dict):  # pylint: disable=too-many-ancestors
     """
     An experiment specification object.
 
@@ -31,7 +31,7 @@ class TomatoSettings(Dict):  # pylint: disable=too-many-ancestors
         """
         Constructor for the data class
 
-        Usage: ``TomatoSettings(dict{...})``
+        Usage: ``TomatoSettingsData(dict{...})``
 
         :param parameters_dict: dictionary with battery specifications
         :param type parameters_dict: dict
@@ -46,7 +46,7 @@ class TomatoSettings(Dict):  # pylint: disable=too-many-ancestors
 
         Uses the voluptuous package for validation. Find out about allowed keys using::
 
-            print(TomatoSettings.schema)
+            print(TomatoSettingsData.schema)
 
         :param parameters_dict: dictionary with battery specifications
         :param type parameters_dict: dict
@@ -62,7 +62,7 @@ class TomatoSettings(Dict):  # pylint: disable=too-many-ancestors
         return json.dumps(object_to_be_serialized)
 
     def get_yaml(self):
-        """Get a YAML file containing the TomatoSettings specs."""
+        """Get a YAML file containing the TomatoSettingsData specs."""
 
         # this can be customized to fit the desired format
         object_to_be_serialized = {"tomato": self.get_dict()}

--- a/aiida_aurora/data/experiment.py
+++ b/aiida_aurora/data/experiment.py
@@ -10,7 +10,7 @@ import yaml
 from aiida.orm import Dict
 
 
-class CyclingSpecs(Dict):  # pylint: disable=too-many-ancestors
+class CyclingSpecsData(Dict):  # pylint: disable=too-many-ancestors
     """
     An experiment specification object.
 
@@ -56,7 +56,7 @@ class CyclingSpecs(Dict):  # pylint: disable=too-many-ancestors
         return json.dumps(object_to_be_serialized)
 
     def get_yaml(self):
-        """Get a YAML file containing the BatterySample specs."""
+        """Get a YAML file containing the BatterySampleData specs."""
 
         # this can be customized to fit the desired format
         object_to_be_serialized = {"method": self.get_dict()}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,10 +50,10 @@ docs = [
 ]
 
 [project.entry-points."aiida.data"]
-"aurora.batterysample" = "aiida_aurora.data.battery:BatterySample"
-"aurora.batterystate" = "aiida_aurora.data.battery:BatteryState"
-"aurora.cyclingspecs" = "aiida_aurora.data.experiment:CyclingSpecs"
-"aurora.tomatosettings" = "aiida_aurora.data.control:TomatoSettings"
+"aurora.batterysample" = "aiida_aurora.data.battery:BatterySampleData"
+"aurora.batterystate" = "aiida_aurora.data.battery:BatteryStateData"
+"aurora.cyclingspecs" = "aiida_aurora.data.experiment:CyclingSpecsData"
+"aurora.tomatosettings" = "aiida_aurora.data.control:TomatoSettingsData"
 
 [project.entry-points."aiida.calculations"]
 "aurora.fake" = "aiida_aurora.calculations.fake:BatteryFakeExperiment"


### PR DESCRIPTION
Closes #5 : some data classes are renamed to avoid confusion.
Closes #7 : after epfl-theos/aiidalab-aurora#8, we change the way Aurora data schemas are loaded and converted to dgbowl-schemas. We use the `aurora/schemas/dgbowl_schemas` module to take care of the conversions.