### PR TITLE
Ci-tests-fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,8 @@ jobs:
       env:
         AIIDA_TEST_BACKEND: ${{ matrix.backend }}
         # show timings of tests
-        PYTEST_ADDOPTS: "--durations=0"
-      run: py.test --cov aiida_aurora --cov-append .
+        PYTEST_ADDOPTS: "--durations=0 --cov=aiida_aurora --cov-append"
+      run: py.test tests
 
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Made `tests` dir the designated directory for testing to prevent pytest from searching too widely, which was causing failures in other branches.

This PR is based on PR #26