### PR TITLE
Pacifist monitoring

### DIFF
--- a/aiida_aurora/utils/cycling_analysis.py
+++ b/aiida_aurora/utils/cycling_analysis.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 
+import numpy as np
 from pandas import DataFrame
 from pandas.io.formats.style import Styler
 
@@ -278,9 +279,6 @@ def process_data(node: CalcJobNode) -> tuple[dict, str, Styler | str]:
         Post-processed data, warning, and analysis | error message.
     """
 
-    if node.process_state and "finished" not in node.process_state.value:
-        return {}, f"Job terminated with message '{node.process_status}'", ""
-
     warning = ""
 
     if node.exit_status:
@@ -289,16 +287,19 @@ def process_data(node: CalcJobNode) -> tuple[dict, str, Styler | str]:
         warning += f"{node.exit_message}" if node.exit_message else generic
         warning += "\n\n"
 
-    if "results" in node.outputs:
-        data = get_data_from_results(node.outputs.results)
-    elif "raw_data" in node.outputs:
-        data = get_data_from_file(node.outputs.raw_data)
-    elif "retrieved" in node.outputs:
-        data = get_data_from_file(node.outputs.retrieved)
-    elif "remote_folder" in node.outputs:
-        data = get_data_from_remote(node.outputs.remote_folder)
+    if node.exit_status is None:
+        data = get_data_from_snapshot(node.base.extras.get("snapshot", {}))
     else:
-        data = {}
+        if "results" in node.outputs:
+            data = get_data_from_results(node.outputs.results)
+        elif "raw_data" in node.outputs:
+            data = get_data_from_file(node.outputs.raw_data)
+        elif "retrieved" in node.outputs:
+            data = get_data_from_file(node.outputs.retrieved)
+        elif "remote_folder" in node.outputs:
+            data = get_data_from_remote(node.outputs.remote_folder)
+        else:
+            data = {}
 
     return data, warning, add_analysis(data)
 
@@ -346,6 +347,11 @@ def get_data_from_remote(source: RemoteData) -> dict:
         return {}
 
 
+def get_data_from_snapshot(snapshot: dict) -> dict:
+    """docstring"""
+    return {k: np.array(v) for k, v in snapshot.items()}
+
+
 def add_analysis(data: dict) -> Styler | str:
     """Return analysis details.
 
@@ -381,4 +387,5 @@ def add_analysis(data: dict) -> Styler | str:
         ]).hide(axis="index")
 
     else:
+
         return "ERROR! Failed to find or parse output"

--- a/aiida_aurora/workflows/cycling_sequence.py
+++ b/aiida_aurora/workflows/cycling_sequence.py
@@ -117,13 +117,34 @@ class CyclingSequenceWorkChain(WorkChain):
 
     def inspect_cycling_step(self):
         """Verify that the last cycling step finished successfully."""
-        last_subprocess = self.ctx.subprocesses[-1]
 
-        if not last_subprocess.is_finished_ok:
-            pkid = last_subprocess.pk
-            stat = last_subprocess.exit_status
-            self.report(f'Cycling substep <pk={pkid}> failed with exit status {stat}')
+        last_step: orm.CalcJobNode = self.ctx.subprocesses[-1]
+
+        if not last_step.is_finished_ok:
+
+            pk = last_step.pk
+            status = last_step.exit_status
+            self.report(f"Process <{pk=}> failed with exit status {status}")
+
+            # not killed by monitor
+            if "🍅" in last_step.base.extras.get("flag", ""):
+
+                exit_codes = BatteryCyclerExperiment.exit_codes
+
+                if status == exit_codes.WARNING_COMPLETED_CANCELLED.status:
+                    # killed by tomato
+                    last_step.base.extras.set("flag", "🚫")
+                else:
+                    # catastrophic error
+                    last_step.base.extras.set("flag", "🚨")
+
             return self.exit_codes.ERROR_IN_CYCLING_STEP
+
+        last_step.base.extras.set("flag", "✅")
+
+        for extra in ("status", "snapshot"):
+            if extra in last_step.base.extras:
+                last_step.base.extras.delete(extra)
 
     def run_cycling_step(self):
         """Run the next cycling step."""
@@ -136,19 +157,24 @@ class CyclingSequenceWorkChain(WorkChain):
             'control_settings': self.inputs.control_settings[protocol_name],
         }
 
-        has_monitors = protocol_name in self.inputs.monitor_settings
+        has_monitors = bool(self.inputs.monitor_settings[protocol_name])
 
         if has_monitors:
             inputs['monitors'] = self.inputs.monitor_settings[protocol_name]
 
-        running = self.submit(BatteryCyclerExperiment, **inputs)
+        running: orm.CalcJobNode = self.submit(
+            BatteryCyclerExperiment,
+            **inputs,
+        )
+
         sample_name = self.inputs.battery_sample.attributes["metadata"]["name"]
         running.label = f"{protocol_name} | {sample_name}"
 
-        if has_monitors:
-            running.set_extra('monitored', True)
-        else:
-            running.set_extra('monitored', False)
+        running.base.extras.set_many({
+            "monitored": has_monitors,
+            "flag": "🍅",
+            "status": "",
+        })
 
         workflow_group = self.inputs.group_label.value
         experiment_group = f"{workflow_group}/{protocol_name}"

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -6,6 +6,7 @@ py:class Logger
 
 py:class orm.ProcessNode
 py:class CalcJobNode
+py:class Transport
 
 py:class aiida_aurora.schemas.battery.Config
 py:class aiida_aurora.schemas.cycling.Config


### PR DESCRIPTION
It is not desired to have monitoring terminate cycling jobs when "fail" conditions are met. Rather, the monitor should flag these jobs for and defer the decision to the user. This PR implements the following:

- [x] Replace kill order with report flagging
- [x] Attach emoji flags as `extras` to better represent job states
- [x] Attach snapshot as `extras` for partial data plotting

Based on #39